### PR TITLE
fix: Add base branch selection checkpoint before PR creation

### DIFF
--- a/AI_CODING_AGENT_GODMODE.md
+++ b/AI_CODING_AGENT_GODMODE.md
@@ -597,8 +597,19 @@ Next: Awaiting approval for Phase [N+1]
    Proceed with PR creation? (yes/no)
    ```
 
-3. **If approved, create PR:**
+3. **If approved, ask for base branch:**
+   ```
+   Which branch should this PR target?
+   - main (production/stable branch)
+   - experimental (testing/development branch)
+   - other (specify)
+
+   Target branch: _____
+   ```
+
+4. **Create PR with specified base branch:**
    ```bash
+   # Replace BASE_BRANCH with user's choice (main, experimental, etc.)
    gh pr create \
      --title "feat: [Brief description] (Closes #ISSUE_NUM)" \
      --body "$(cat <<'EOF'
@@ -629,10 +640,15 @@ Next: Awaiting approval for Phase [N+1]
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    EOF
    )" \
-     --base main
+     --base BASE_BRANCH
    ```
 
-4. **Report PR creation:**
+   **Common base branches:**
+   - `--base main` - For production-ready changes
+   - `--base experimental` - For testing/development changes
+   - `--base develop` - If using GitFlow workflow
+
+5. **Report PR creation:**
    ```
    ✅ Pull Request created: https://github.com/owner/repo/pull/XXX
 


### PR DESCRIPTION
Problem: PR creation hardcoded --base main, causing PRs to target wrong branch when user wants to target experimental or other branches.

Solution: Added Step 3 checkpoint asking user which branch to target before creating PR. Updated gh pr create command to use user-specified base branch.

Changes:
- Step 3: New checkpoint asking for base branch (main/experimental/other)
- Step 4: Updated gh pr create to use --base BASE_BRANCH placeholder
- Added common base branches reference (main, experimental, develop)
- Renumbered steps (old step 4 is now step 5)

Example workflow:
1. User approves PR creation
2. Agent asks: "Which branch should this PR target?"
3. User responds: "experimental"
4. Agent runs: gh pr create --base experimental ...

Prevents future PRs from defaulting to main when experimental intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)