### PR TITLE
feat: harden hooks, fix version drift, add resilience patterns

### DIFF
--- a/AI_CODING_AGENT_GODMODE.md
+++ b/AI_CODING_AGENT_GODMODE.md
@@ -1,10 +1,10 @@
 # AI Coding Agent Standard Operating Protocol (SOP)
 
-**Version:** 5.3.0-experimental
+**Version:** 5.14.0-experimental
 **Last Updated:** February 2026
 **Purpose:** Safe, effective AI-assisted software development
 
-**Current:** 7 workflow commands (`/explore`, `/plan`, `/implement`, `/review`, `/learn`, `/ship`, `/loop`), 26 reusable skill packages, flat `godmode:` namespace, natural workflow chaining via `AskUserQuestion`, Agent Teams integration, per-project review configuration, and autonomous development loops.
+**Current:** 7 workflow commands (`/explore`, `/plan`, `/implement`, `/review`, `/learn`, `/ship`, `/loop`), 27 reusable skill packages, flat `godmode:` namespace, natural workflow chaining via `AskUserQuestion`, Agent Teams integration, per-project review configuration, and autonomous development loops.
 
 ---
 
@@ -930,7 +930,7 @@ After completing a feature or fixing a tricky bug:
 - `templates/ADR_TEMPLATE.md` - Architecture decisions
 - `agents/review/*.md` - 15 review agent definitions
 - `agents/research/*.md` - 4 research agent definitions
-- `skills/*/SKILL.md` - 26 reusable skill packages
+- `skills/*/SKILL.md` - 27 reusable skill packages
 - `commands/*.md` - 7 workflow commands
 - `guides/CONTEXT_OPTIMIZATION.md` - Advanced context techniques
 - `guides/MULTI_AGENT_PATTERNS.md` - Complex coordination
@@ -940,4 +940,4 @@ After completing a feature or fixing a tricky bug:
 
 ---
 
-*Last Updated: February 2026 | Version: 5.3.0-experimental | Next Review: Quarterly*
+*Last Updated: February 2026 | Version: 5.14.0-experimental | Next Review: Quarterly*

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -252,6 +252,6 @@ Use the recovery skill within `/implement`:
 
 ---
 
-**Version:** 5.4.0-experimental
+**Version:** 5.14.0-experimental
 **Last Updated:** February 2026
 **Full docs:** See `README.md`

--- a/agents/research/DISPATCH_TABLE.md
+++ b/agents/research/DISPATCH_TABLE.md
@@ -1,0 +1,78 @@
+<!-- CANONICAL SOURCE for research agent configuration -->
+<!-- CONSUMERS: skills/explore/SKILL.md, skills/generate-plan/SKILL.md, skills/deepen-plan/SKILL.md -->
+<!-- When updating this file, sync all consumers. Consumers inline this content. -->
+
+# Research Agent Dispatch Table
+
+Standard configuration for the 4-agent parallel research pattern used across explore, generate-plan, and deepen-plan skills.
+
+---
+
+## Launch Rules
+
+**CRITICAL:** Launch all applicable research agents simultaneously via Task tool in a single message.
+
+**Smart research decision (for agents 3 & 4):**
+- High-risk topics (security, payments, external APIs) → always research
+- Strong local context (good patterns, CLAUDE.md has guidance) → skip external
+- Uncertainty or unfamiliar territory → research
+
+## Agent Table
+
+| # | Agent | Condition | Model | Task Tool Config |
+|---|-------|-----------|-------|-----------------|
+| 1 | **Codebase Research Agent** | Always runs | (built-in) | `subagent_type: "Explore"`, reads `agents/research/codebase-researcher.md` for process |
+| 2 | **Learnings Research Agent** | Always runs (if `docs/solutions/` has files) | haiku | `subagent_type: "general-purpose"`, `model: "haiku"`, searches `docs/solutions/` per `agents/research/learnings-researcher.md` |
+| 3 | **Best Practices Research Agent** | Conditional: unfamiliar technology, external APIs, or user explicitly asks | haiku | `subagent_type: "general-purpose"`, `model: "haiku"`, web search per `agents/research/best-practices-researcher.md` |
+| 4 | **Framework Docs Research Agent** | Conditional: known framework detected in package.json/Gemfile/requirements.txt/go.mod/Cargo.toml | haiku | `subagent_type: "general-purpose"`, `model: "haiku"`, queries Context7 MCP per `agents/research/framework-docs-researcher.md` |
+
+## Prompt Templates
+
+**Codebase Research Agent prompt:**
+```
+Explore the [target] in this codebase. Identify:
+1. Key files and their purposes
+2. Architecture patterns used
+3. Important functions/classes
+4. Dependencies and relationships
+5. Potential areas of concern
+
+CRITICAL: Do NOT write any files. Return your findings as text in your response.
+Do NOT create intermediary files, analysis documents, or temp files.
+The orchestrator handles all file writes.
+
+Provide a structured summary suitable for planning new work.
+```
+
+**Learnings Research Agent prompt:**
+```
+Search docs/solutions/ for past solutions relevant to [target].
+Use multi-pass Grep strategy: tags → category → keywords → full-text.
+Return relevant findings with applicability assessment.
+
+CRITICAL: Do NOT write any files. Return your findings as text in your response.
+Do NOT create intermediary files, analysis documents, or temp files.
+The orchestrator handles all file writes.
+```
+
+## Thoroughness Levels
+
+**Thoroughness level for Codebase Research Agent:**
+- Simple queries (single file/class): "quick"
+- Feature areas: "medium"
+- Full codebase: "very thorough"
+
+## Incorporating Findings
+
+**Incorporate findings into:**
+- Technical Approach section (use patterns found in codebase)
+- Risks section (apply gotchas from past solutions)
+- Test Strategy (past testing approaches for similar features)
+
+## Deepen-Plan Variant
+
+When used in deepen-plan, the pattern differs slightly:
+- Codebase Research spawns **1 agent per plan section** needing codebase context (not 1 total)
+- Learnings Research runs once for the entire plan
+- The orchestrator reads each agent's definition file and inlines the content into the prompt
+- Research agents still need file access (Grep, Read, Glob) — they should NOT need to read their own definition file

--- a/commands/loop.md
+++ b/commands/loop.md
@@ -236,6 +236,12 @@ IF review_round >= review_max_rounds AND NOT review_clean:
 
 Each review worker is a `general-purpose` Task subagent spawned with `mode: bypassPermissions`. It acts as team lead, spawning review agents as parallel teammates via Agent Teams.
 
+**Agent Teams fallback:** If TeamCreate is not available or fails, the review worker should fall back to running the fresh-eyes-review skill pattern using sequential Task subagents instead. Skip Phase 2 below and let the skill manage the full review flow:
+
+```
+Skill(skill="fresh-eyes-review", args="full mode")
+```
+
 ```
 You are running a FULL fresh-eyes code review using Agent Teams for parallel
 execution. You have ZERO memory of previous work — read files for ALL context.
@@ -255,7 +261,7 @@ You are the TEAM LEAD — you coordinate specialists, consolidate, and validate.
 
 ## Phase 2: Spawn Review Team (Parallel)
 
-1. Create a team with TeamCreate
+1. Attempt to create a team with TeamCreate. If TeamCreate fails or is unavailable, fall back to Skill('fresh-eyes-review') and skip to Phase 3.
 2. For EACH selected specialist, spawn a teammate (general-purpose Task, mode: bypassPermissions)
    with this prompt template:
 

--- a/hooks/protect-protocol-files.sh
+++ b/hooks/protect-protocol-files.sh
@@ -15,7 +15,10 @@ fi
 INPUT=$(cat)
 
 # Extract file path from the tool input JSON
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.content // empty' 2>/dev/null)
+# Both Edit and Write tools use .tool_input.file_path as the path key.
+# The .tool_input.content fallback was removed intentionally — it matched
+# file content, not file paths, creating a security bypass.
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 
 if [ -z "$FILE_PATH" ]; then
   exit 0

--- a/hooks/review-gate.sh
+++ b/hooks/review-gate.sh
@@ -6,13 +6,16 @@
 # Checks for .todos/review-verdict.md. If absent or verdict is BLOCK,
 # prevents the commit. Override with SKIP_REVIEW=1.
 
-# Allow override
+# Read tool input from stdin (must happen before any early exit to avoid broken pipes)
+INPUT=$(cat)
+
+# Allow override (with audit trail — persistent + stderr)
 if [ "$SKIP_REVIEW" = "1" ]; then
+  echo "$(date -Iseconds) SKIP_REVIEW bypass" >> .todos/review-audit.log 2>/dev/null
+  echo "WARNING: Review gate bypassed (SKIP_REVIEW=1)" >&2
+  echo '{"decision": "allow", "reason": "SKIP_REVIEW=1 override — review gate bypassed by user"}'
   exit 0
 fi
-
-# Read tool input from stdin
-INPUT=$(cat)
 
 # Check if this is a git commit command
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -29,12 +32,36 @@ if [ ! -f "$VERDICT_FILE" ]; then
   exit 0
 fi
 
-# Extract verdict from YAML frontmatter
-VERDICT=$(grep -m1 "^verdict:" "$VERDICT_FILE" | sed 's/verdict: *//' | tr -d '[:space:]')
-
-if [ "$VERDICT" = "BLOCK" ]; then
-  echo '{"decision": "block", "reason": "Review verdict is BLOCK. Fix critical findings before committing, or set SKIP_REVIEW=1 to override."}'
+# Check file is not empty
+if [ ! -s "$VERDICT_FILE" ]; then
+  echo '{"decision": "block", "reason": "Review verdict file exists but is empty. Run /review to generate a proper verdict, or set SKIP_REVIEW=1 to override."}'
   exit 0
 fi
 
-exit 0
+# Extract verdict from YAML frontmatter
+VERDICT=$(grep -m1 "^verdict:" "$VERDICT_FILE" | sed 's/verdict: *//' | tr -d '[:space:]' | tr -d '"' | tr -d "'")
+
+if [ -z "$VERDICT" ]; then
+  echo '{"decision": "block", "reason": "Review verdict file exists but has no verdict field. Run /review to generate a proper verdict, or set SKIP_REVIEW=1 to override."}'
+  exit 0
+fi
+
+# Allowlist of recognized verdicts — unknown verdicts block as a safety default
+case "$VERDICT" in
+  BLOCK)
+    echo '{"decision": "block", "reason": "Review verdict is BLOCK. Fix critical findings before committing, or set SKIP_REVIEW=1 to override."}'
+    exit 0
+    ;;
+  FIX_BEFORE_COMMIT)
+    echo '{"decision": "block", "reason": "Review verdict is FIX_BEFORE_COMMIT. Fix HIGH findings before committing, or set SKIP_REVIEW=1 to override."}'
+    exit 0
+    ;;
+  APPROVED|APPROVED_WITH_NOTES)
+    # Permit commit
+    exit 0
+    ;;
+  *)
+    jq -n --arg v "$VERDICT" '{"decision": "block", "reason": ("Unrecognized review verdict \u0027" + $v + "\u0027. Expected BLOCK, FIX_BEFORE_COMMIT, APPROVED_WITH_NOTES, or APPROVED. Set SKIP_REVIEW=1 to override.")}'
+    exit 0
+    ;;
+esac

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -18,10 +18,30 @@ fi
 if [ -f ".todos/review-verdict.md" ]; then
   TIMESTAMP=$(grep -m1 "^timestamp:" ".todos/review-verdict.md" | sed 's/timestamp: *//' | tr -d '"' | tr -d '[:space:]')
   if [ -n "$TIMESTAMP" ]; then
-    VERDICT_EPOCH=$(date -d "$TIMESTAMP" +%s 2>/dev/null || echo "0")
+    # Validate timestamp is ISO 8601 format before passing to date
+    if ! echo "$TIMESTAMP" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}'; then
+      WARNINGS="${WARNINGS}NOTE: Review verdict timestamp is not valid ISO 8601: ${TIMESTAMP}\n"
+      VERDICT_EPOCH="0"
+    elif date -d "2000-01-01" +%s >/dev/null 2>&1; then
+      # GNU date (Linux)
+      VERDICT_EPOCH=$(date -d "$TIMESTAMP" +%s 2>/dev/null || echo "0")
+    elif date -j -f "%Y-%m-%dT%H:%M:%S" "2000-01-01T00:00:00" +%s >/dev/null 2>&1; then
+      # BSD date (macOS) — strip timezone suffix for parsing
+      CLEAN_TS=$(echo "$TIMESTAMP" | sed 's/Z$//; s/[+-][0-9][0-9]:[0-9][0-9]$//; s/[+-][0-9]\{4\}$//')
+      VERDICT_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$CLEAN_TS" +%s 2>/dev/null || echo "0")
+    else
+      # Fallback: skip staleness check
+      VERDICT_EPOCH="0"
+      WARNINGS="${WARNINGS}NOTE: Could not parse review verdict timestamp (unsupported date command).\n"
+    fi
     NOW_EPOCH=$(date +%s)
-    AGE_HOURS=$(( (NOW_EPOCH - VERDICT_EPOCH) / 3600 ))
-    if [ "$AGE_HOURS" -gt 24 ]; then
+    # Guard: skip if parse failed (0) or timestamp is in the future (clock skew)
+    if [ "$VERDICT_EPOCH" != "0" ] && [ "$NOW_EPOCH" -ge "$VERDICT_EPOCH" ]; then
+      AGE_HOURS=$(( (NOW_EPOCH - VERDICT_EPOCH) / 3600 ))
+    else
+      AGE_HOURS=0
+    fi
+    if [ "$VERDICT_EPOCH" != "0" ] && [ "$AGE_HOURS" -gt 24 ]; then
       WARNINGS="${WARNINGS}NOTE: Review verdict is ${AGE_HOURS}h old. May be stale if you've made changes since.\n"
     fi
   fi

--- a/skills/bump-version/SKILL.md
+++ b/skills/bump-version/SKILL.md
@@ -31,6 +31,11 @@ Bump version in plugin.json + marketplace.json on the feature branch, then updat
 
 ## Process
 
+### Step 0: Project Guard
+
+1. **Check for plugin structure:** Verify `.claude-plugin/plugin.json` exists and contains valid JSON with a `version` field
+2. **If absent or malformed:** Display "Cannot bump version: `.claude-plugin/plugin.json` not found or invalid. This skill is for GODMODE plugin releases only." and **STOP** — do not proceed to Step 1.
+
 ### Step 1: Detect Context
 
 1. **Current branch:** `git branch --show-current`

--- a/skills/deepen-plan/SKILL.md
+++ b/skills/deepen-plan/SKILL.md
@@ -29,6 +29,8 @@ Methodology for enriching a plan with parallel research, multi-agent review, and
 
 ### Phase 2: Research Layer
 
+<!-- Research agent config — canonical source: agents/research/DISPATCH_TABLE.md -->
+
 **CRITICAL: Launch ALL research agents IN PARALLEL.**
 
 **Before launching:** The orchestrator reads each agent's definition file and inlines the content into the prompt. Research agents still need file access (Grep, Read, Glob) to explore the codebase — that's their job. But they should NOT need to read their own definition file.

--- a/skills/explore/SKILL.md
+++ b/skills/explore/SKILL.md
@@ -65,6 +65,8 @@ AskUserQuestion:
 
 ## Step 2: Launch Research Agents in Parallel
 
+<!-- Research agent config — canonical source: agents/research/DISPATCH_TABLE.md -->
+
 **CRITICAL:** Launch all applicable research agents simultaneously via Task tool in a single message.
 
 **Smart research decision (for agents 3 & 4):**

--- a/skills/generate-plan/SKILL.md
+++ b/skills/generate-plan/SKILL.md
@@ -38,6 +38,8 @@ Methodology for creating plans with integrated multi-agent research, brainstorm 
 
 ### 1. Parallel Research (Self-Sufficient)
 
+<!-- Research agent config — canonical source: agents/research/DISPATCH_TABLE.md -->
+
 **CRITICAL:** Launch all applicable research agents simultaneously via Task tool in a single message. This skill runs its own research — no prior `/explore` required.
 
 **Smart research decision (for agents 3 & 4):**

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -168,12 +168,13 @@ AskUserQuestion:
       description: "Race conditions, deadlocks, async patterns"
     - label: "Error Handling Reviewer"
       description: "Try/catch coverage, external call resilience"
-    - label: "Data Validation Reviewer"
-      description: "Input validation, parsing, sanitization"
+      # Note: Data Validation coverage is provided by Edge Case Reviewer (input validation,
+      # schema validation, allowlist checks) and Security Reviewer (injection, sanitization).
+      # Config & Secrets coverage is provided by Security Reviewer (secrets exposure,
+      # config file safety, credential management). Separate agents were removed to reduce
+      # review overhead without coverage gaps.
     - label: "Dependency Reviewer"
       description: "Package updates, supply chain, license compliance"
-    - label: "Config & Secrets Reviewer"
-      description: "Env vars, hardcoded secrets, config hygiene"
     - label: "Testing Adequacy Reviewer"
       description: "Test coverage, test quality, missing tests"
     - label: "Documentation Reviewer"

--- a/skills/todos/SKILL.md
+++ b/skills/todos/SKILL.md
@@ -6,7 +6,6 @@ referenced_by:
   - skills/fresh-eyes-review/SKILL.md
   - skills/commit-and-pr/SKILL.md
   - skills/start-issue/SKILL.md
-  - commands/start-issue.md
 ---
 
 # File-Based Todo Tracking Skill
@@ -18,6 +17,15 @@ System for tracking review findings and tasks using committed markdown files.
 ## Directory Convention
 
 All todo files live in `.todos/` at the project root. This directory is committed to git for persistence across sessions.
+
+---
+
+## Reserved Filenames
+
+The following files in `.todos/` are managed by other skills and should not be manually created or modified:
+
+- `review-verdict.md` — Written by `fresh-eyes-review`, read by `review-gate.sh` hook and `/ship`
+- `review-report.md` — Written by `fresh-eyes-review`, contains full consolidated review findings
 
 ---
 


### PR DESCRIPTION
## Summary

- **Hook hardening**: Fixed security bypass in protect-protocol-files, added BSD date compatibility to session-start, hardened review-gate with VERDICT allowlist, stdin consumption order, jq-based JSON output, and persistent audit trail
- **Hooks wiring**: Registered all 3 hook scripts in settings.json (were dead code — scripts existed but not wired to Claude Code events)
- **Version sync**: Fixed 11-version drift across docs (5.3.0/5.4.0 → 5.14.0-experimental)
- **Ghost agent removal**: Removed 2 deleted agents (Data Validation, Config & Secrets) from setup options, documented coverage transfer
- **Research deduplication**: Created canonical DISPATCH_TABLE.md for research agent config duplicated across 3 skills
- **Resilience**: Added Agent Teams fallback to loop review worker, project guard to bump-version
- **Doc fixes**: Fixed skill count, reserved filenames in todos, dead cross-references
- **Learning captured**: Shell hook hardening best practices doc

## Changes

| Area | Files | What Changed |
|------|-------|-------------|
| Hooks | `hooks/protect-protocol-files.sh` | Removed `.content` fallback (security bypass), documented key extraction |
| Hooks | `hooks/review-gate.sh` | Stdin before early exit, VERDICT allowlist (case), jq for JSON, audit log, empty file handling |
| Hooks | `hooks/session-start.sh` | ISO 8601 validation, BSD date compat (Z/+HHMM/+HH:MM), future timestamp guard |
| Config | `settings.json` | Wired all 3 hooks to Claude Code events |
| Docs | `AI_CODING_AGENT_GODMODE.md`, `QUICK_START.md` | Version 5.14.0-experimental, skill count 27 |
| Skills | `skills/setup/SKILL.md` | Removed ghost agents, documented coverage transfer |
| Skills | `skills/bump-version/SKILL.md` | Step 0 project guard with JSON validation |
| Skills | `skills/todos/SKILL.md` | Reserved filenames section, removed dead cross-ref |
| Skills | `skills/explore/SKILL.md`, `generate-plan/SKILL.md`, `deepen-plan/SKILL.md` | Canonical source comments |
| Commands | `commands/loop.md` | Agent Teams fallback with code-fenced Skill invocation |
| New | `agents/research/DISPATCH_TABLE.md` | Canonical research agent configuration |
| New | `docs/solutions/best-practices/shell-hook-hardening-patterns-20260218.md` | Learning capture |

## Test plan

- [x] All 3 hook scripts tested manually (session-start, review-gate, protect-protocol-files)
- [x] SKIP_REVIEW bypass verified: consumes stdin, outputs JSON + stderr warning, writes audit log
- [x] VERDICT allowlist verified: BLOCK/FIX_BEFORE_COMMIT block, APPROVED/APPROVED_WITH_NOTES pass, unknown blocks with jq-encoded message
- [x] BSD date timezone stripping covers Z, +HH:MM, +HHMM formats
- [x] Future timestamp guard produces AGE_HOURS=0
- [x] 3 rounds of fresh-eyes-review (Lite), all HIGH findings fixed

## Review

- Fresh Eyes Review: **APPROVED_WITH_NOTES** (3 rounds, all HIGH findings resolved)
- Remaining MEDIUM/LOW deferred: exit code semantics, audit log mkdir, DRY in dispatch table, YAML comment placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)